### PR TITLE
Allow specifying multiple $Files using string array

### DIFF
--- a/DSCResources/MSFT_xRobocopy/MSFT_xRobocopy.psm1
+++ b/DSCResources/MSFT_xRobocopy/MSFT_xRobocopy.psm1
@@ -12,7 +12,7 @@ function Get-TargetResource
         [System.String]
         $Destination,
 
-        [System.String]
+        [System.String[]]
         $Files,
 
         [System.UInt32]
@@ -82,7 +82,7 @@ function Set-TargetResource
         [System.String]
         $Destination,
 
-        [System.String]
+        [System.String[]]
         $Files,
 
         [System.UInt32]
@@ -137,7 +137,7 @@ function Test-TargetResource
         [System.String]
         $Destination,
 
-        [System.String]
+        [System.String[]]
         $Files,
 
         [System.UInt32]
@@ -218,7 +218,7 @@ function Get-RobocopyArguments
         [System.String]
         $Destination,
 
-        [System.String]
+        [System.String[]]
         $Files,
 
         [System.UInt32]

--- a/DSCResources/MSFT_xRobocopy/MSFT_xRobocopy.schema.mof
+++ b/DSCResources/MSFT_xRobocopy/MSFT_xRobocopy.schema.mof
@@ -3,7 +3,7 @@ class MSFT_xRobocopy : OMI_BaseResource
 {
     [Key, Description("Source Directory, Drive or UNC path.")] String Source;
     [Key, Description("Destination Dir, Drive or UNC path.")] String Destination;
-    [Write, Description("File(s) to copy  (names/wildcards: default is all files).")] String Files;
+    [Write, Description("File(s) to copy  (names/wildcards: default is all files).")] String Files[];
     [Write, Description("Number of Retries on failed copies: default 1 million.")] UInt32 Retry;
     [Write, Description("Wait time between retries: default is 30 seconds.")] UInt32 Wait;
     [Write, Description("Copy subdirectories, including Empty ones.")] Boolean SubdirectoriesIncludingEmpty;
@@ -15,4 +15,3 @@ class MSFT_xRobocopy : OMI_BaseResource
     [Write, Description("Robocopy has MANY configuration options. Too many to present them all as DSC parameters effectively. Use this option to set additional parameters. Each parameter should be a separate array member. This array will be combined with main argument array. For a list of options run Robocopy /??? in a shell window.")] String AdditionalArgs[];
     [Read, ValueMap{"Present", "Absent"}, Values{"Present", "Absent"}, Description("Will indicate whether Destination is in sync with Source")] String Ensure;
 };
-

--- a/Examples/xRobocopy.SimpleCopyOptions.ps1
+++ b/Examples/xRobocopy.SimpleCopyOptions.ps1
@@ -30,6 +30,14 @@ configuration RobocopyExample
             Files = '*.sql'
         }
 
+        #this will copy only specified files in source directory
+        xRobocopy CopyByUsingFilesFilter
+        {
+            Source = 'C:\temp\source'
+            Destination = 'C:\temp\destination'
+            Files = @('test1.txt', 'test2.txt')
+        }
+
         #this is equivalent of using /e option
         xRobocopy CopyFilesAndSubfolders
         {


### PR DESCRIPTION
This enables array input for `Files` parameter:

```powershell
xRobocopy CopyByUsingFilesFilter
{
  Source = 'C:\temp\source'
  Destination = 'C:\temp\destination'
  Files = @('test1.txt', 'test2.txt')
}
```

while keeping the (currently supported) single input `Files = 'test.txt'` and glob pattern `Files = '*.sql'` intact.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xrobocopy/32)
<!-- Reviewable:end -->
